### PR TITLE
Added config option to toggle on/off effective sql string when using  p6spy

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ decorator.datasource.p6spy.logging=slf4j
 decorator.datasource.p6spy.log-file=spy.log
 # Custom log format, if specified com.p6spy.engine.spy.appender.CustomLineFormat will be used with this log format
 decorator.datasource.p6spy.log-format=
+decorator.datasource.p6spy.include-parameter-values=true
 ```
 
 Also you can configure P6Spy manually using one of available configuration methods. For more information please refer to the [P6Spy Configuration Guide](http://p6spy.readthedocs.io/en/latest/configandusage.html)

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ decorator.datasource.p6spy.logging=slf4j
 decorator.datasource.p6spy.log-file=spy.log
 # Custom log format, if specified com.p6spy.engine.spy.appender.CustomLineFormat will be used with this log format
 decorator.datasource.p6spy.log-format=
-decorator.datasource.p6spy.include-parameter-values=true
+decorator.datasource.p6spy.tracing.include-parameter-values=true
 ```
 
 Also you can configure P6Spy manually using one of available configuration methods. For more information please refer to the [P6Spy Configuration Guide](http://p6spy.readthedocs.io/en/latest/configandusage.html)

--- a/datasource-decorator-spring-boot-autoconfigure/src/main/java/com/github/gavlyukovskiy/boot/jdbc/decorator/p6spy/P6SpyProperties.java
+++ b/datasource-decorator-spring-boot-autoconfigure/src/main/java/com/github/gavlyukovskiy/boot/jdbc/decorator/p6spy/P6SpyProperties.java
@@ -52,6 +52,13 @@ public class P6SpyProperties {
      */
     private String logFormat;
 
+    /**
+     * Report the effective sql string (with '?' replaced with real values) to tracing systems.
+     *
+     * NOTE this setting does not affect the logging message.
+     */
+    private boolean includeParameterValues = true;
+
     public enum P6SpyLogging {
         SYSOUT,
         SLF4J,

--- a/datasource-decorator-spring-boot-autoconfigure/src/main/java/com/github/gavlyukovskiy/boot/jdbc/decorator/p6spy/P6SpyProperties.java
+++ b/datasource-decorator-spring-boot-autoconfigure/src/main/java/com/github/gavlyukovskiy/boot/jdbc/decorator/p6spy/P6SpyProperties.java
@@ -53,15 +53,24 @@ public class P6SpyProperties {
     private String logFormat;
 
     /**
-     * Report the effective sql string (with '?' replaced with real values) to tracing systems.
-     *
-     * NOTE this setting does not affect the logging message.
+     * Tracing related properties
      */
-    private boolean includeParameterValues = true;
+    private P6SpyTracing tracing = new P6SpyTracing();
 
     public enum P6SpyLogging {
         SYSOUT,
         SLF4J,
         FILE
+    }
+
+    @Getter
+    @Setter
+    public static class P6SpyTracing {
+        /**
+         * Report the effective sql string (with '?' replaced with real values) to tracing systems.
+         * <p>
+         * NOTE this setting does not affect the logging message.
+         */
+        private boolean includeParameterValues = true;
     }
 }

--- a/datasource-decorator-spring-boot-autoconfigure/src/main/java/com/github/gavlyukovskiy/cloud/sleuth/SleuthListenerAutoConfiguration.java
+++ b/datasource-decorator-spring-boot-autoconfigure/src/main/java/com/github/gavlyukovskiy/cloud/sleuth/SleuthListenerAutoConfiguration.java
@@ -63,7 +63,8 @@ public class SleuthListenerAutoConfiguration {
 
         @Bean
         public TracingJdbcEventListener tracingJdbcEventListener(Tracer tracer, DataSourceNameResolver dataSourceNameResolver) {
-            return new TracingJdbcEventListener(tracer, dataSourceNameResolver, dataSourceDecoratorProperties.getSleuth().getInclude());
+            return new TracingJdbcEventListener(tracer, dataSourceNameResolver,
+                    dataSourceDecoratorProperties.getSleuth().getInclude(), dataSourceDecoratorProperties.getP6spy().isIncludeParameterValues());
         }
     }
 

--- a/datasource-decorator-spring-boot-autoconfigure/src/main/java/com/github/gavlyukovskiy/cloud/sleuth/SleuthListenerAutoConfiguration.java
+++ b/datasource-decorator-spring-boot-autoconfigure/src/main/java/com/github/gavlyukovskiy/cloud/sleuth/SleuthListenerAutoConfiguration.java
@@ -64,7 +64,8 @@ public class SleuthListenerAutoConfiguration {
         @Bean
         public TracingJdbcEventListener tracingJdbcEventListener(Tracer tracer, DataSourceNameResolver dataSourceNameResolver) {
             return new TracingJdbcEventListener(tracer, dataSourceNameResolver,
-                    dataSourceDecoratorProperties.getSleuth().getInclude(), dataSourceDecoratorProperties.getP6spy().isIncludeParameterValues());
+                    dataSourceDecoratorProperties.getSleuth().getInclude(),
+                    dataSourceDecoratorProperties.getP6spy().getTracing().isIncludeParameterValues());
         }
     }
 

--- a/datasource-decorator-spring-boot-autoconfigure/src/main/java/com/github/gavlyukovskiy/cloud/sleuth/TracingJdbcEventListener.java
+++ b/datasource-decorator-spring-boot-autoconfigure/src/main/java/com/github/gavlyukovskiy/cloud/sleuth/TracingJdbcEventListener.java
@@ -41,9 +41,12 @@ public class TracingJdbcEventListener extends SimpleJdbcEventListener implements
     private final DataSourceNameResolver dataSourceNameResolver;
 
     private final TracingListenerStrategy<ConnectionInformation, StatementInformation, ResultSetInformation> strategy;
+    private final boolean includeParameterValues;
 
-    TracingJdbcEventListener(Tracer tracer, DataSourceNameResolver dataSourceNameResolver, List<TraceType> traceTypes) {
+    TracingJdbcEventListener(Tracer tracer, DataSourceNameResolver dataSourceNameResolver, List<TraceType> traceTypes,
+                             boolean includeParameterValues) {
         this.dataSourceNameResolver = dataSourceNameResolver;
+        this.includeParameterValues = includeParameterValues;
         this.strategy = new TracingListenerStrategy<>(tracer, traceTypes);
     }
 
@@ -117,7 +120,7 @@ public class TracingJdbcEventListener extends SimpleJdbcEventListener implements
     }
 
     private String getSql(StatementInformation statementInformation) {
-        return StringUtils.hasText(statementInformation.getSqlWithValues())
+        return includeParameterValues && StringUtils.hasText(statementInformation.getSqlWithValues())
                 ? statementInformation.getSqlWithValues()
                 : statementInformation.getSql();
     }

--- a/datasource-decorator-spring-boot-autoconfigure/src/test/java/com/github/gavlyukovskiy/cloud/sleuth/TracingJdbcEventListenerTests.java
+++ b/datasource-decorator-spring-boot-autoconfigure/src/test/java/com/github/gavlyukovskiy/cloud/sleuth/TracingJdbcEventListenerTests.java
@@ -121,7 +121,7 @@ class TracingJdbcEventListenerTests {
 
     @Test
     void testShouldUsePlaceholderInSqlTagOfSpansForPreparedStatementIfIncludeParameterValuesIsSetToFalse() {
-        contextRunner.withPropertyValues("decorator.datasource.p6spy.include-parameter-values=false")
+        contextRunner.withPropertyValues("decorator.datasource.p6spy.tracing.include-parameter-values=false")
                 .run(context -> {
                     DataSource dataSource = context.getBean(DataSource.class);
                     ArrayListSpanReporter spanReporter = context.getBean(ArrayListSpanReporter.class);


### PR DESCRIPTION
PR for #38 

Added the config `decorator.datasource.p6spy.include-parameter-values` and default it to `true` for backward compatibility. 
