### PR TITLE
Add support for Spring Boot 2.4 with Spring Cloud Sleuth 3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,11 +24,11 @@ version = scmVersion.version
 subprojects {
     apply(plugin = "java")
 
-    extra["springBootVersion"] = "2.3.1.RELEASE"
+    extra["springBootVersion"] = "2.4.3"
     extra["p6SpyVersion"] = "3.9.0"
     extra["datasourceProxyVersion"] = "1.7"
     extra["flexyPoolVersion"] = "2.2.1"
-    extra["sleuthVersion"] = "2.2.1.RELEASE"
+    extra["sleuthVersion"] = "3.0.1"
 
     extra["release"] = listOf(
             "datasource-decorator-spring-boot-autoconfigure",

--- a/datasource-decorator-spring-boot-autoconfigure/build.gradle.kts
+++ b/datasource-decorator-spring-boot-autoconfigure/build.gradle.kts
@@ -24,11 +24,9 @@ dependencies {
     compileOnly("com.vladmihalcea.flexy-pool:flexy-micrometer-metrics:${project.extra["flexyPoolVersion"]}")
 
     compileOnly("org.springframework.boot:spring-boot-starter-actuator:${project.extra["springBootVersion"]}")
-    compileOnly("org.springframework.cloud:spring-cloud-sleuth-core:${project.extra["sleuthVersion"]}")
+    compileOnly("org.springframework.cloud:spring-cloud-starter-sleuth:${project.extra["sleuthVersion"]}")
 
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
     testImplementation("com.h2database:h2:1.4.199")
-    testImplementation("org.assertj:assertj-core:3.12.2")
     testImplementation("org.springframework.boot:spring-boot-starter-test:${project.extra["springBootVersion"]}")
 
     testImplementation("p6spy:p6spy:${project.extra["p6SpyVersion"]}")
@@ -39,7 +37,8 @@ dependencies {
     testImplementation("com.vladmihalcea.flexy-pool:flexy-tomcatcp:${project.extra["flexyPoolVersion"]}")
     testImplementation("com.vladmihalcea.flexy-pool:flexy-micrometer-metrics:${project.extra["flexyPoolVersion"]}")
 
-    testImplementation("org.springframework.cloud:spring-cloud-sleuth-core:${project.extra["sleuthVersion"]}")
+    testImplementation("org.springframework.cloud:spring-cloud-starter-sleuth:${project.extra["sleuthVersion"]}")
+    testImplementation("io.zipkin.brave:brave-tests:5.13.3")
 
     testImplementation("commons-dbcp:commons-dbcp:1.4")
     testImplementation("org.apache.commons:commons-dbcp2:2.6.0")

--- a/datasource-decorator-spring-boot-autoconfigure/src/main/java/com/github/gavlyukovskiy/cloud/sleuth/SleuthListenerAutoConfiguration.java
+++ b/datasource-decorator-spring-boot-autoconfigure/src/main/java/com/github/gavlyukovskiy/cloud/sleuth/SleuthListenerAutoConfiguration.java
@@ -31,7 +31,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -45,7 +44,12 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnClass(Tracer.class)
 @ConditionalOnBean(Tracer.class)
 @ConditionalOnProperty(name = "decorator.datasource.sleuth.enabled", havingValue = "true", matchIfMissing = true)
-@AutoConfigureAfter({ TraceAutoConfiguration.class, DataSourceDecoratorAutoConfiguration.class })
+@AutoConfigureAfter(
+        value = DataSourceDecoratorAutoConfiguration.class,
+        name = {
+                "org.springframework.cloud.sleuth.autoconfig.brave.BraveAutoConfiguration",
+                "org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration"
+        })
 public class SleuthListenerAutoConfiguration {
 
     public static final String SPAN_SQL_QUERY_TAG_NAME = "sql";

--- a/datasource-decorator-spring-boot-autoconfigure/src/test/java/com/github/gavlyukovskiy/cloud/sleuth/SleuthP6SpyListenerAutoConfigurationTests.java
+++ b/datasource-decorator-spring-boot-autoconfigure/src/test/java/com/github/gavlyukovskiy/cloud/sleuth/SleuthP6SpyListenerAutoConfigurationTests.java
@@ -25,8 +25,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
-import org.springframework.cloud.sleuth.log.SleuthLogAutoConfiguration;
+import org.springframework.cloud.sleuth.autoconfig.brave.BraveAutoConfiguration;
 
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -38,8 +37,7 @@ class SleuthP6SpyListenerAutoConfigurationTests {
             .withConfiguration(AutoConfigurations.of(
                     DataSourceAutoConfiguration.class,
                     DataSourceDecoratorAutoConfiguration.class,
-                    TraceAutoConfiguration.class,
-                    SleuthLogAutoConfiguration.class,
+                    BraveAutoConfiguration.class,
                     SleuthListenerAutoConfiguration.class,
                     PropertyPlaceholderAutoConfiguration.class
             ))

--- a/datasource-decorator-spring-boot-autoconfigure/src/test/java/com/github/gavlyukovskiy/cloud/sleuth/SleuthProxyDataSourceListenerAutoConfigurationTests.java
+++ b/datasource-decorator-spring-boot-autoconfigure/src/test/java/com/github/gavlyukovskiy/cloud/sleuth/SleuthProxyDataSourceListenerAutoConfigurationTests.java
@@ -26,8 +26,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
-import org.springframework.cloud.sleuth.log.SleuthLogAutoConfiguration;
+import org.springframework.cloud.sleuth.autoconfig.brave.BraveAutoConfiguration;
 
 import javax.sql.DataSource;
 
@@ -41,8 +40,7 @@ class SleuthProxyDataSourceListenerAutoConfigurationTests {
             .withConfiguration(AutoConfigurations.of(
                     DataSourceAutoConfiguration.class,
                     DataSourceDecoratorAutoConfiguration.class,
-                    TraceAutoConfiguration.class,
-                    SleuthLogAutoConfiguration.class,
+                    BraveAutoConfiguration.class,
                     SleuthListenerAutoConfiguration.class,
                     PropertyPlaceholderAutoConfiguration.class
             ))

--- a/datasource-decorator-spring-boot-autoconfigure/src/test/java/com/github/gavlyukovskiy/cloud/sleuth/TestSpanHandlerConfiguration.java
+++ b/datasource-decorator-spring-boot-autoconfigure/src/test/java/com/github/gavlyukovskiy/cloud/sleuth/TestSpanHandlerConfiguration.java
@@ -17,16 +17,16 @@
 package com.github.gavlyukovskiy.cloud.sleuth;
 
 import brave.sampler.Sampler;
-import org.springframework.cloud.sleuth.util.ArrayListSpanReporter;
+import brave.test.TestSpanHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-class SavingSpanReporterConfiguration {
+class TestSpanHandlerConfiguration {
 
     @Bean
-    public ArrayListSpanReporter spanReporter() {
-        return new ArrayListSpanReporter();
+    public TestSpanHandler spanHandler() {
+        return new TestSpanHandler();
     }
 
     @Bean

--- a/samples/README.md
+++ b/samples/README.md
@@ -10,7 +10,7 @@ Run sample application on port 8081 with next endpoints:
 
 **P6Spy**
 ```
-gradlew :samples:p6spy-sample:bootRun
+./gradlew :samples:p6spy-sample:bootRun
 ```
 
 add `-Pzipkin` if you have [Zipkin](https://github.com/openzipkin/zipkin) running on port 9411
@@ -18,13 +18,13 @@ add `-Pzipkin` if you have [Zipkin](https://github.com/openzipkin/zipkin) runnin
 
 **Datasource Proxy**
 ```
-gradlew :samples:datasource-proxy-sample:bootRun
+./gradlew :samples:datasource-proxy-sample:bootRun
 ```
 
 add `-Pzipkin` if you have [Zipkin](https://github.com/openzipkin/zipkin) running on port 9411
 
 **FlexyPool**
 ```
-gradlew :samples:flexy-pool-sample:bootRun
+./gradlew :samples:flexy-pool-sample:bootRun
 ```
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -13,15 +13,14 @@ Run sample application on port 8081 with next endpoints:
 ./gradlew :samples:p6spy-sample:bootRun
 ```
 
-add `-Pzipkin` if you have [Zipkin](https://github.com/openzipkin/zipkin) running on port 9411
-
+add `--args='--spring.profiles.active=zipkin'` if you have [Zipkin](https://github.com/openzipkin/zipkin) running on port 9411 (e.g via `docker run -p 9411:9411 openzipkin/zipkin`)
 
 **Datasource Proxy**
 ```
 ./gradlew :samples:datasource-proxy-sample:bootRun
 ```
 
-add `-Pzipkin` if you have [Zipkin](https://github.com/openzipkin/zipkin) running on port 9411
+add `--args='--spring.profiles.active=zipkin'` if you have [Zipkin](https://github.com/openzipkin/zipkin) running on port 9411
 
 **FlexyPool**
 ```

--- a/samples/datasource-proxy-sample/build.gradle.kts
+++ b/samples/datasource-proxy-sample/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot").version("2.3.1.RELEASE")
+    id("org.springframework.boot").version("2.4.3")
 }
 
 repositories {
@@ -21,14 +21,13 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
     implementation("org.springframework.boot:spring-boot-starter-aop")
 
-    implementation("org.springframework.cloud:spring-cloud-sleuth-core:2.2.3.RELEASE")
-    implementation("org.springframework.cloud:spring-cloud-sleuth-zipkin:2.2.3.RELEASE")
+    implementation("org.springframework.cloud:spring-cloud-starter-sleuth:3.0.1")
+    implementation("org.springframework.cloud:spring-cloud-sleuth-zipkin:3.0.1")
 
     implementation("com.h2database:h2")
     implementation("org.apache.commons:commons-io:1.3.2")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
 }
 
 tasks {

--- a/samples/datasource-proxy-sample/build.gradle.kts
+++ b/samples/datasource-proxy-sample/build.gradle.kts
@@ -32,14 +32,17 @@ dependencies {
 
 tasks {
     bootRun {
-        val args = args!!
-        if (project.hasProperty("zipkin")) {
-            args.add("--spring.zipkin.enabled=true")
-            args.add("--spring.sleuth.enabled=true")
-        }
-        if (project.hasProperty("args")) {
-            val userArgs = project.findProperty("args") as String
-            userArgs.split(" ").forEach { args.add(it) }
+        doFirst {
+            val args = args!!
+            if (project.hasProperty("zipkin")) {
+                args.add("--spring.zipkin.enabled=true")
+                args.add("--spring.sleuth.enabled=true")
+            }
+            if (project.hasProperty("args")) {
+                val userArgs = project.findProperty("args") as String
+                userArgs.split(" ").forEach { args.add(it) }
+            }
+            setArgs(args)
         }
     }
 
@@ -47,5 +50,3 @@ tasks {
         useJUnitPlatform()
     }
 }
-
-

--- a/samples/datasource-proxy-sample/build.gradle.kts
+++ b/samples/datasource-proxy-sample/build.gradle.kts
@@ -31,21 +31,6 @@ dependencies {
 }
 
 tasks {
-    bootRun {
-        doFirst {
-            val args = args!!
-            if (project.hasProperty("zipkin")) {
-                args.add("--spring.zipkin.enabled=true")
-                args.add("--spring.sleuth.enabled=true")
-            }
-            if (project.hasProperty("args")) {
-                val userArgs = project.findProperty("args") as String
-                userArgs.split(" ").forEach { args.add(it) }
-            }
-            setArgs(args)
-        }
-    }
-
     test {
         useJUnitPlatform()
     }

--- a/samples/datasource-proxy-sample/src/main/resources/application-zipkin.yml
+++ b/samples/datasource-proxy-sample/src/main/resources/application-zipkin.yml
@@ -1,0 +1,5 @@
+spring:
+  sleuth:
+    enabled: true
+  zipkin:
+    enabled: true

--- a/samples/flexy-pool-sample/build.gradle.kts
+++ b/samples/flexy-pool-sample/build.gradle.kts
@@ -28,14 +28,6 @@ dependencies {
 }
 
 tasks {
-    bootRun {
-        val args = args!!
-        if (project.hasProperty("args")) {
-            val userArgs = project.findProperty("args") as String
-            userArgs.split(" ").forEach { args.add(it) }
-        }
-    }
-
     test {
         useJUnitPlatform()
     }

--- a/samples/flexy-pool-sample/build.gradle.kts
+++ b/samples/flexy-pool-sample/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot").version("2.3.1.RELEASE")
+    id("org.springframework.boot").version("2.4.3")
 }
 
 repositories {
@@ -25,7 +25,6 @@ dependencies {
     implementation("org.apache.commons:commons-io:1.3.2")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
 }
 
 tasks {

--- a/samples/p6spy-sample/build.gradle.kts
+++ b/samples/p6spy-sample/build.gradle.kts
@@ -32,14 +32,17 @@ dependencies {
 
 tasks {
     bootRun {
-        val args = args!!
-        if (project.hasProperty("zipkin")) {
-            args.add("--spring.zipkin.enabled=true")
-            args.add("--spring.sleuth.enabled=true")
-        }
-        if (project.hasProperty("args")) {
-            val userArgs = project.findProperty("args") as String
-            userArgs.split(" ").forEach { args.add(it) }
+        doFirst {
+            val args = args!!
+            if (project.hasProperty("zipkin")) {
+                args.add("--spring.zipkin.enabled=true")
+                args.add("--spring.sleuth.enabled=true")
+            }
+            if (project.hasProperty("args")) {
+                val userArgs = project.findProperty("args") as String
+                userArgs.split(" ").forEach { args.add(it) }
+            }
+            setArgs(args)
         }
     }
 

--- a/samples/p6spy-sample/build.gradle.kts
+++ b/samples/p6spy-sample/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot").version("2.3.1.RELEASE")
+    id("org.springframework.boot").version("2.4.3")
 }
 
 repositories {
@@ -21,14 +21,13 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
     implementation("org.springframework.boot:spring-boot-starter-aop")
 
-    implementation("org.springframework.cloud:spring-cloud-sleuth-core:2.2.3.RELEASE")
-    implementation("org.springframework.cloud:spring-cloud-sleuth-zipkin:2.2.3.RELEASE")
+    implementation("org.springframework.cloud:spring-cloud-starter-sleuth:3.0.1")
+    implementation("org.springframework.cloud:spring-cloud-sleuth-zipkin:3.0.1")
 
     implementation("com.h2database:h2")
     implementation("org.apache.commons:commons-io:1.3.2")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
 }
 
 tasks {
@@ -48,5 +47,3 @@ tasks {
         useJUnitPlatform()
     }
 }
-
-

--- a/samples/p6spy-sample/build.gradle.kts
+++ b/samples/p6spy-sample/build.gradle.kts
@@ -31,21 +31,6 @@ dependencies {
 }
 
 tasks {
-    bootRun {
-        doFirst {
-            val args = args!!
-            if (project.hasProperty("zipkin")) {
-                args.add("--spring.zipkin.enabled=true")
-                args.add("--spring.sleuth.enabled=true")
-            }
-            if (project.hasProperty("args")) {
-                val userArgs = project.findProperty("args") as String
-                userArgs.split(" ").forEach { args.add(it) }
-            }
-            setArgs(args)
-        }
-    }
-
     test {
         useJUnitPlatform()
     }

--- a/samples/p6spy-sample/src/main/resources/application-zipkin.yml
+++ b/samples/p6spy-sample/src/main/resources/application-zipkin.yml
@@ -1,0 +1,5 @@
+spring:
+  sleuth:
+    enabled: true
+  zipkin:
+    enabled: true


### PR DESCRIPTION
As discussed with @gavlyukovskiy this fixes #56, by changing the `AutoConfigureAfter` to use string based dependencies which work with both
- Sleuth 2.x (`TraceAutoConfiguration` - gone in Sleuth 3)
- Sleuth 3.x (`BraveAutoConfiguration` - doesn't exist in Sleuth 2) - required with Spring Boot 2.4

Tested to be working
- ran the actual automated tests with Boot 2.3 + Sleuth 2.x (using `./gradlew -Psleuth2 :datasource-decorator-spring-boot-autoconfigure:test` from [this different branch](https://github.com/chadlwilson/spring-boot-data-source-decorator/tree/sleuth-3-with-backward-compat-and-test-hack) - but couldn't find a clean way to integrate with Gradle to run both.
- using the samples with Zipkin against Spring Boot `2.3.1` and Sleuth `2.2.1`  (2.x is Hoxton and only compatible up to Spring Boot `2.3`)
- using the samples with Zipkin against Spring Boot `2.4.3` and Sleuth `3.0.1`

Also fixed running the samples by Gradle with `-Pzipkin` which didn't seem to be working.