### PR TITLE
Optional decoration of routing datasources

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,4 +289,4 @@ public DataSourceDecorator customDecorator() {
 
 #### Disable Decorating
 
-If you want to disable decorating set `decorator.datasource.exclude-beans` with bean names you want to exclude or set `decorator.datasource.enabled` to `false` if you want to disable all decorators for all datasources.
+If you want to disable decorating set `decorator.datasource.exclude-beans` with bean names you want to exclude or set `decorator.datasource.enabled` to `false` if you want to disable all decorators for all datasources. Also, you can disable decorating for `AbstractRoutingDataSource` setting property `decorator.datasource.ignore-routing-data-sources` to `true`

--- a/README.md
+++ b/README.md
@@ -289,4 +289,6 @@ public DataSourceDecorator customDecorator() {
 
 #### Disable Decorating
 
-If you want to disable decorating set `decorator.datasource.exclude-beans` with bean names you want to exclude or set `decorator.datasource.enabled` to `false` if you want to disable all decorators for all datasources. Also, you can disable decorating for `AbstractRoutingDataSource` setting property `decorator.datasource.ignore-routing-data-sources` to `true`
+If you want to disable decorating set `decorator.datasource.exclude-beans` with bean names you want to exclude.
+Also, you can disable decorating for `AbstractRoutingDataSource` setting property `decorator.datasource.ignore-routing-data-sources` to `true`
+Set `decorator.datasource.enabled` to `false` if you want to disable all decorators for all datasources. 

--- a/datasource-decorator-spring-boot-autoconfigure/src/main/java/com/github/gavlyukovskiy/boot/jdbc/decorator/DataSourceDecoratorBeanPostProcessor.java
+++ b/datasource-decorator-spring-boot-autoconfigure/src/main/java/com/github/gavlyukovskiy/boot/jdbc/decorator/DataSourceDecoratorBeanPostProcessor.java
@@ -23,6 +23,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
 
 import javax.sql.DataSource;
 import java.util.ArrayList;
@@ -52,6 +53,7 @@ public class DataSourceDecoratorBeanPostProcessor implements BeanPostProcessor, 
     public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
         if (bean instanceof DataSource
                 && !ScopedProxyUtils.isScopedTarget(beanName)
+                && !((bean instanceof AbstractRoutingDataSource) && getDataSourceDecoratorProperties().isIgnoreRoutingDataSources())
                 && !getDataSourceDecoratorProperties().getExcludeBeans().contains(beanName)) {
             DataSource dataSource = (DataSource) bean;
             DataSource decoratedDataSource = dataSource;

--- a/datasource-decorator-spring-boot-autoconfigure/src/main/java/com/github/gavlyukovskiy/boot/jdbc/decorator/DataSourceDecoratorProperties.java
+++ b/datasource-decorator-spring-boot-autoconfigure/src/main/java/com/github/gavlyukovskiy/boot/jdbc/decorator/DataSourceDecoratorProperties.java
@@ -43,6 +43,11 @@ public class DataSourceDecoratorProperties {
      * Beans that won't be decorated.
      */
     private Collection<String> excludeBeans = Collections.emptyList();
+    
+    /**
+     * If AbstractRoutingDataSource will be decorated or not
+     */
+    private boolean ignoreRoutingDataSources = false;
 
     @NestedConfigurationProperty
     private DataSourceProxyProperties datasourceProxy = new DataSourceProxyProperties();
@@ -66,6 +71,10 @@ public class DataSourceDecoratorProperties {
 
     public Collection<String> getExcludeBeans() {
         return this.excludeBeans;
+    }
+
+    public boolean isIgnoreRoutingDataSources() {
+        return ignoreRoutingDataSources;
     }
 
     public DataSourceProxyProperties getDatasourceProxy() {
@@ -96,6 +105,11 @@ public class DataSourceDecoratorProperties {
     public void setExcludeBeans(Collection<String> excludeBeans) {
         this.excludeBeans = excludeBeans;
     }
+
+    public void setIgnoreRoutingDataSources(boolean ignoreRoutingDataSources) {
+        this.ignoreRoutingDataSources = ignoreRoutingDataSources;
+    }
+    
 
     public void setDatasourceProxy(DataSourceProxyProperties datasourceProxy) {
         this.datasourceProxy = datasourceProxy;


### PR DESCRIPTION
Add property `decorator.datasource.ignore-routing-data-sources` to allow disabling AbstractRoutingDataSource. decoration

Close #73 