### PR TITLE
Set required field for custom `AbstractSlowQueryLoggingListener`

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Query:["SELECT SLEEP(301000)"]
 Params:[]
 ```
 
-You can add custom `QueryExecutionListener` by registering them in the context, as well you can override `ParameterTransformer`, `QueryTransformer` and `ConnectionIdManager`:
+You can add custom `QueryExecutionListener` by registering them in the context, as well you can override `ParameterTransformer`, `QueryTransformer`, `ConnectionIdManager` and `AbstractSlowQueryLoggingListener`:
 ```java
 @Bean
 public QueryExecutionListener queryExecutionListener() {

--- a/datasource-decorator-spring-boot-autoconfigure/src/main/java/com/github/gavlyukovskiy/boot/jdbc/decorator/dsproxy/ProxyDataSourceBuilderConfigurer.java
+++ b/datasource-decorator-spring-boot-autoconfigure/src/main/java/com/github/gavlyukovskiy/boot/jdbc/decorator/dsproxy/ProxyDataSourceBuilderConfigurer.java
@@ -19,6 +19,7 @@ package com.github.gavlyukovskiy.boot.jdbc.decorator.dsproxy;
 import net.ttddyy.dsproxy.listener.MethodExecutionListener;
 import net.ttddyy.dsproxy.listener.QueryCountStrategy;
 import net.ttddyy.dsproxy.listener.QueryExecutionListener;
+import net.ttddyy.dsproxy.listener.logging.AbstractSlowQueryLoggingListener;
 import net.ttddyy.dsproxy.listener.logging.CommonsLogLevel;
 import net.ttddyy.dsproxy.listener.logging.SLF4JLogLevel;
 import net.ttddyy.dsproxy.proxy.ResultSetProxyLogicFactory;
@@ -140,6 +141,12 @@ public class ProxyDataSourceBuilderConfigurer {
             proxyDataSourceBuilder.countQuery(queryCountStrategy);
         }
         if (listeners != null) {
+            for (QueryExecutionListener listener : listeners) {
+                if (listener instanceof AbstractSlowQueryLoggingListener slowQueryListener) {
+                    slowQueryListener.setThreshold(datasourceProxy.getSlowQuery().getThreshold());
+                    slowQueryListener.setThresholdTimeUnit(TimeUnit.SECONDS);
+                }
+            }
             listeners.forEach(proxyDataSourceBuilder::listener);
         }
         if (methodExecutionListeners != null) {


### PR DESCRIPTION
This PR came from the issue https://github.com/gavlyukovskiy/spring-boot-data-source-decorator/issues/124.

This allows users to create custom SlowQueryListeners. Originally, the `ThresholdTimeUnit` field of the custom `AbstractSlowQueryLoggingListener` was null and subsequently caused an NPE in `Thread.schedule()`.

I'm new to open source PR, so there may be some things I'm missing. If you have any fixes, please feel free to let me know.